### PR TITLE
Fix to avoid infinite loop during unicast send failure

### DIFF
--- a/pim.c
+++ b/pim.c
@@ -368,6 +368,7 @@ void send_pim_unicast(char *buf, u_int32 src, u_int32 dst, int type, int datalen
         else
             logit(LOG_WARNING, errno, "sendto from %s to %s",
 		  inet_fmt(src, s1, sizeof(s1)), inet_fmt(dst, s2, sizeof(s2)));
+        return;
     }
 
     IF_DEBUG(DEBUG_PIM_DETAIL) {


### PR DESCRIPTION
If any error other than EINTR is returned by sento, break out of the loop.
Currenty if sendto returns a failure it will always loop causing an initite
loop if the failure is not transient, ex: EMSGSIZE or EHOSTUNREACH.
