### PR TITLE
pimd segfaults if invalid message PIM join/prune messages are received

### DIFF
--- a/pimd.h
+++ b/pimd.h
@@ -179,6 +179,7 @@ typedef struct pim_encod_grp_addr_ {
     u_int8      masklen;
     u_int32     mcast_addr;
 } pim_encod_grp_addr_t;
+#define PIM_ENCODE_GRP_ADDR_LEN 8
 
 /* Encoded-Source */
 typedef struct pim_encod_src_addr_ {
@@ -188,6 +189,8 @@ typedef struct pim_encod_src_addr_ {
     u_int8      masklen;
     u_int32     src_addr;
 } pim_encod_src_addr_t;
+#define PIM_ENCODE_SRC_ADDR_LEN 8
+
 #define USADDR_RP_BIT 0x1
 #define USADDR_WC_BIT 0x2
 #define USADDR_S_BIT  0x4


### PR DESCRIPTION
Hi.

Found out that suitable malformed join/prune messages can segfault pimd. As code already states (TODO: Sanity check for message length...), fix was found from Kame's pim6sd. I do have couple of .pcap's as well, but could not attach them here.
