### PR TITLE
Refactor PIM Join/Prune send logic to allow more than ~75 multicast r…

### DIFF
--- a/ChangeLog.org
+++ b/ChangeLog.org
@@ -5,7 +5,7 @@
 #+LaTeX_HEADER: \usepackage{parskip} \usepackage{a4wide}
 #+LaTeX_CLASS_OPTIONS: [twoside, colorlinks=true, linkcolor=blue, urlcolor=blue]
 
-* Version 2.3.1: UNRELEASED
+* Version 2.3.1: November 15, 2015
 
 Bug fix release.
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 #VERSION       = $(shell git tag -l | tail -1)
-VERSION       = 2.3.1-beta1
+VERSION       = 2.3.1
 EXEC          = pimd
 CONFIG        = $(EXEC).conf
 PKG           = $(EXEC)-$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ mandir        = $(prefix)/share/man/man8
 ## Common
 CPPFLAGS     += -D_PATH_SYSCONF=\"$(sysconfdir)\"
 CFLAGS       += $(INCLUDES) $(DEFS) $(USERCOMPILE)
-CFLAGS       += -W -Wall -Werror -fno-strict-aliasing
+CFLAGS       += -W -Wall -Wextra -fno-strict-aliasing
 LDLIBS        = $(EXTRA_LIBS)
 OBJS          = $(IGMP_OBJS) $(ROUTER_OBJS) $(PIM_OBJS) $(DVMRP_OBJS) $(EXTRA_OBJS)
 SRCS          = $(OBJS:.o=.c)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 #VERSION       = $(shell git tag -l | tail -1)
-VERSION       = 2.3.1
+VERSION       = 2.3.2-beta1
 EXEC          = pimd
 CONFIG        = $(EXEC).conf
 PKG           = $(EXEC)-$(VERSION)

--- a/configure
+++ b/configure
@@ -77,7 +77,7 @@ usage()
     print "\n"
     print "  --debug                  Enable debuggable build, -g and -O0\n"
     print "  --prefix=PATH            Base installation directory, default: /usr/local/\n"
-    print "  --sysconfidir=PATH       Path to pimd.conf, default: /etc/\n"
+    print "  --sysconfdir=PATH        Path to pimd.conf, default: /etc/\n"
     print "  --embedded-libc          Linux system with uClibc or musl libc.  These two\n"
     print "                           C libraries have strlcpy() and strlcat()"
     print "\n"

--- a/defs.h
+++ b/defs.h
@@ -144,11 +144,6 @@ typedef void (*ihfunc_t) (int, fd_set *);
 /*
  * Miscellaneous constants and macros
  */
-/* #if (!(defined(__bsdi__)) && !(defined(KERNEL))) */
-#ifndef KERNEL
-#define max(a, b)               ((a) < (b) ? (b) : (a))
-#define min(a, b)               ((a) > (b) ? (b) : (a))
-#endif
 
 #define ENABLINGSTR(val)        (val) ? "enabling" : "disabling"
 

--- a/defs.h
+++ b/defs.h
@@ -242,13 +242,13 @@ typedef void (*ihfunc_t) (int, fd_set *);
 
 /*
  * TODO: recalculate the messages sizes, probably with regard to the MTU
- * TODO: cleanup
  */
-#define MAX_JP_MESSAGE_SIZE     8192
+/* We must assume "safe" maximum atleast until we handle MTU correctly. */
+#define MAX_JP_MESSAGE_SIZE     (576 \
+				- sizeof(struct ip) \
+				- sizeof(pim_header_t) \
+				- sizeof(pim_jp_header_t))
 #define MAX_JP_MESSAGE_POOL_NUMBER 8
-#define MAX_JOIN_LIST_SIZE      1500
-#define MAX_PRUNE_LIST_SIZE     1500
-
 
 #ifdef RSRR
 #define BIT_ZERO(X)		((X) = 0)

--- a/mrt.c
+++ b/mrt.c
@@ -173,9 +173,9 @@ mrtentry_t *find_route(uint32_t source, uint32_t group, uint16_t flags, char cre
 		    /* Exact (S,G) entry found */
 		    logit(LOG_DEBUG, 0 , "find_route: exact (S,G) entry found");
 		    return mrt;
-		} else {
-		    logit(LOG_DEBUG, 0 , "find_route:(S,G) entry not found");
 		}
+
+		logit(LOG_DEBUG, 0 , "find_route:(S,G) entry not found");
 	    }
 
 	    /* No (S,G) entry. Return the (*,G) entry (if exist) */

--- a/mrt.c
+++ b/mrt.c
@@ -137,14 +137,15 @@ mrtentry_t *find_route(uint32_t source, uint32_t group, uint16_t flags, char cre
 
     if (flags & (MRTF_SG | MRTF_WC)) {
 	if (!IN_MULTICAST(ntohl(group))) {
-	    logit(LOG_WARNING, 0, "Not a multicast addr....");
+	    logit(LOG_WARNING, 0, "find_route: Not a multicast group address (%s) ...",
+		  inet_fmt(group, s1, sizeof(s1)));
 	    return NULL;
 	}
     }
 
     if (flags & MRTF_SG) {
 	if (!inet_valid_host(source) && !IN_PIM_SSM_RANGE(group)) {
-	    logit(LOG_WARNING, 0, "Not a valid host (%s)....",
+	    logit(LOG_WARNING, 0, "find_route: Not a valid host (%s) ...",
 		  inet_fmt(source, s1, sizeof(s1)));
 	    return NULL;
 	}

--- a/pim_proto.c
+++ b/pim_proto.c
@@ -652,7 +652,7 @@ int receive_pim_register(uint32_t reg_src, uint32_t reg_dst, char *msg, size_t l
     is_null   = ntohl(reg->reg_flags) & PIM_REGISTER_NULL_REGISTER_BIT;
 
     /* initialize the pointer to the encapsulated packet */
-    ip = (struct ip *)(reg + 1);
+    ip = (struct ip *)(msg + sizeof(pim_header_t) + sizeof(pim_register_t));
 
     /* check the IP version (especially for the NULL register...see above) */
     if (ip->ip_v != IPVERSION && (! is_null)) {

--- a/pim_proto.c
+++ b/pim_proto.c
@@ -1031,7 +1031,8 @@ int receive_pim_register_stop(uint32_t reg_src, uint32_t reg_dst, char *msg, siz
     GET_EGADDR(&egaddr,  data);
     GET_EUADDR(&eusaddr, data);
 
-    logit(LOG_INFO, 0, "Received PIM_REGISTER_STOP from RP %s to %s for src = %s and group = %s", inet_fmt(reg_src, s1, sizeof(s1)), inet_fmt(reg_dst, s2, sizeof(s2)),
+    logit(LOG_INFO, 0, "Received PIM_REGISTER_STOP from RP %s to %s for src = %s and group = %s",
+	  inet_fmt(reg_src, s1, sizeof(s1)), inet_fmt(reg_dst, s2, sizeof(s2)),
 	  inet_fmt(eusaddr.unicast_addr, s3, sizeof(s3)),
 	  inet_fmt(egaddr.mcast_addr, s4, sizeof(s4)));
 
@@ -1070,9 +1071,8 @@ send_pim_register_stop(uint32_t reg_src, uint32_t reg_dst, uint32_t inner_grp, u
     char   *buf;
     uint8_t *data;
 
-    if (IN_PIM_SSM_RANGE(inner_grp)) {
+    if (IN_PIM_SSM_RANGE(inner_grp))
 	return TRUE;
-    }
 
     logit(LOG_INFO, 0, "Send PIM REGISTER STOP from %s to router %s for src = %s and group = %s",
 	  inet_fmt(reg_src, s1, sizeof(s1)), inet_fmt(reg_dst, s2, sizeof(s2)),
@@ -2371,7 +2371,7 @@ int add_jp_entry(pim_nbr_entry_t *pim_nbr, uint16_t holdtime, uint32_t group,
     if (!bjpm) {
 	bjpm = get_jp_working_buff();
 	if (!bjpm) {
-	    logit(LOG_ERR, 0, "Failed allocating working buffer in add_jp_entry()\n");
+	    logit(LOG_ERR, 0, "Failed allocating working buffer in add_jp_entry()");
 	    exit (-1);
 	}
 

--- a/pim_proto.c
+++ b/pim_proto.c
@@ -949,11 +949,7 @@ int send_pim_register(char *packet)
 	buf += sizeof(pim_register_t);
 
 	/* Copy the data packet at the back of the register packet */
-#ifdef HAVE_IP_HDRINCL_BSD_ORDER
-	pktlen = ip->ip_len;
-#else
 	pktlen = ntohs(ip->ip_len);
-#endif
 	memcpy(buf, ip, pktlen);
 
 	pktlen += sizeof(pim_register_t); /* 'sizeof(struct ip) + sizeof(pim_header_t)' added by send_pim()  */
@@ -996,11 +992,7 @@ int send_pim_null_register(mrtentry_t *mrtentry)
     ip->ip_id    = 0;
     ip->ip_off   = 0;
     ip->ip_p     = IPPROTO_UDP;			/* XXX: bogus */
-#ifdef HAVE_IP_HDRINCL_BSD_ORDER
-    ip->ip_len   = sizeof(struct ip);
-#else
     ip->ip_len   = htons(sizeof(struct ip));
-#endif
     ip->ip_ttl   = MINTTL; /* TODO: XXX: check whether need to setup the ttl */
     ip->ip_src.s_addr = mrtentry->source->address;
     ip->ip_dst.s_addr = mrtentry->group->group;

--- a/pim_proto.c
+++ b/pim_proto.c
@@ -47,7 +47,7 @@ typedef struct {
 static int restart_dr_election     (struct uvif *v);
 static int parse_pim_hello         (char *msg, size_t len, uint32_t src, pim_hello_opts_t *opts);
 static void cache_nbr_settings     (pim_nbr_entry_t *nbr, pim_hello_opts_t *opts);
-static int send_pim_register_stop  (uint32_t reg_src, uint32_t reg_dst, uint32_t inner_source, uint32_t inner_grp);
+static int send_pim_register_stop  (uint32_t reg_src, uint32_t reg_dst, uint32_t inner_grp, uint32_t inner_source);
 static build_jp_message_t *get_jp_working_buff (void);
 static void return_jp_working_buff (pim_nbr_entry_t *pim_nbr);
 static void pack_jp_message        (pim_nbr_entry_t *pim_nbr);


### PR DESCRIPTION
…eceivers.

Gather Joins/Prunes to buffer only up to the point where the PIM message is at
the most 576 bytes on the wire, previous buffer size was 8192 which was way
too large to fit anywhere else than massive jumbo-frame MTU links. The problem
only occurred after there were ~75+ or more receivers behind one link with
MTU of 1500.

 * Change all J/P buffers to be dependent on MAX_JP_MESSAGE_SIZE rather than
   having separate limits for different buffers.

 * Added logic that verifies that no larger than MAX_JP_MESSAGE_SIZE messages
   are crafted to be sent into the network.

 * Prevent (*,*,RP) J/P from creating empty group entries when received.
   This was caused by logic that assumed that if curr_group != group then we
   must pack the group even though the group might not have any joins/prunes.
   (Not verified that this actually works as intended.)

 * Prevent (*,*,RP) J/P from clearing the normal J/P group and mask info.
   (Not verified that this actually works as intended.)

 * Removed "dead" logic that caused reaching of 254 groups in single J/P to
   trigger a premature send of J/P message that would little later lead to
   use-after-free. Moved the logic one function earlier and set the pointer.
   Steps:
   2437:pack_jp_message(pim_nbr);
     2677:send_jp_message(pim_nbr);
       2733:return_jp_working_buff(pim_nbr);
	     2656:free(bjpm);
   2460:bjmp->curr_group = group