### PR TITLE
PIM Assert state correction

### DIFF
--- a/pim_proto.c
+++ b/pim_proto.c
@@ -2868,9 +2868,9 @@ int receive_pim_assert(uint32_t src, uint32_t dst __attribute__((unused)), char 
 
 	/* Have to remove that outgoing vifi from mrt */
 	VIFM_SET(vifi, mrt->asserted_oifs);
-	/* TODO: XXX: TIMER implem. dependency! */
-	if (mrt->timer < PIM_ASSERT_TIMEOUT)
-	    SET_TIMER(mrt->timer, PIM_ASSERT_TIMEOUT);
+	mrt->flags |= MRTF_ASSERTED;
+	if (mrt->assert_timer < PIM_ASSERT_TIMEOUT)
+	    SET_TIMER(mrt->assert_timer, PIM_ASSERT_TIMEOUT);
 	/* TODO: XXX: check that the timer of all affected routing entries
 	 * has been restarted.
 	 */

--- a/pim_proto.c
+++ b/pim_proto.c
@@ -2823,7 +2823,7 @@ int receive_pim_assert(uint32_t src, uint32_t dst __attribute__((unused)), char 
 	    mrt2 = NULL;
 	}
 
-	if (mrt2) {
+	if (mrt2 && (mrt2->flags & MRTF_NEW)) {
 	    mrt2->flags &= ~MRTF_NEW;
 	    /* TODO: XXX: The spec doesn't say what entry timer value
 	     * to use when the routing entry is created because of asserts.

--- a/pim_proto.c
+++ b/pim_proto.c
@@ -2894,6 +2894,10 @@ int receive_pim_assert(uint32_t src, uint32_t dst __attribute__((unused)), char 
 				     */
 	}
 
+	/* If we do not have upstream router at the moment, we must drop the assert message */
+        if (mrt->upstream == NULL) 
+            return TRUE;
+
 	/* TODO: where to get the local metric and preference from?
 	 * system call or mrt is fine?
 	 */

--- a/timer.c
+++ b/timer.c
@@ -494,7 +494,9 @@ void age_routes(void)
 		    /* The (*,G) entry */
 		    /* outgoing interfaces timers */
 		    change_flag = FALSE;
-		    assert_timer_expired = (TIMEOUT(mrt_grp->assert_timer) && mrt_grp->flags & MRTF_ASSERTED);
+		    assert_timer_expired = 0;
+		    if (mrt_grp->flags & MRTF_ASSERTED)
+			assert_timer_expired = TIMEOUT(mrt_grp->assert_timer);
 		    for (vifi = 0; vifi < numvifs; vifi++) {
 			if (VIFM_ISSET(vifi, mrt_grp->joined_oifs))
 			    IF_TIMEOUT(mrt_grp->vif_timers[vifi]) {
@@ -573,7 +575,9 @@ void age_routes(void)
 
 		    /* outgoing interfaces timers */
 		    change_flag = FALSE;
-		    assert_timer_expired = (TIMEOUT(mrt_srcs->assert_timer) && mrt_srcs->flags & MRTF_ASSERTED);
+		    assert_timer_expired = 0;
+		    if (mrt_srcs->flags & MRTF_ASSERTED)
+			assert_timer_expired = TIMEOUT(mrt_srcs->assert_timer);
 		    for (vifi = 0; vifi < numvifs; vifi++) {
 			if (VIFM_ISSET(vifi, mrt_srcs->joined_oifs)) {
 			    /* TODO: checking for reg_num_vif is slow! */


### PR DESCRIPTION
Proposal for assert state handling fixes to issue #63. It might be the case that `MRTF_ASSERTED` flag was meant to be used for inbound ASSERT detection only, but I took it into outbound handling as well. Had to add check for `mrt->upstream` pointer as well, as it was fairly easy to get `pimd` to crash without that. 

With these changes ASSERT state is cleared after 180 seconds (hard coded value). Is this the "right" fix; I am not sure.