### PR TITLE
Optimized multicast stream creation

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -558,6 +558,7 @@ extern int	receive_pim_join_prune	(uint32_t src, uint32_t dst, char *msg, size_t
 extern int	join_or_prune		(mrtentry_t *mrtentry_ptr, pim_nbr_entry_t *upstream_router);
 extern int	receive_pim_assert	(uint32_t src, uint32_t dst, char *msg, size_t len);
 extern int	send_pim_assert		(uint32_t source, uint32_t group, vifi_t vifi, mrtentry_t *mrtentry_ptr);
+extern void     send_pim_join           (pim_nbr_entry_t *pim_nbr, mrtentry_t *mrt, uint16_t flags, uint16_t holdtime);
 extern int	send_periodic_pim_join_prune (vifi_t vifi, pim_nbr_entry_t *pim_nbr, uint16_t holdtime);
 extern int	add_jp_entry		(pim_nbr_entry_t *pim_nbr, uint16_t holdtime, uint32_t group, uint8_t grp_msklen,
                                          uint32_t source, uint8_t src_msklen,  uint16_t addr_flags, uint8_t join_prune);

--- a/pim_proto.c
+++ b/pim_proto.c
@@ -2173,6 +2173,24 @@ int receive_pim_join_prune(uint32_t src, uint32_t dst __attribute__((unused)), c
     return TRUE;
 }
 
+/*
+ * Function for sending single PIM-JOIN instantly.
+ */
+void send_pim_join(pim_nbr_entry_t *pim_nbr, mrtentry_t *mrt, uint16_t flags, uint16_t holdtime)
+{
+    if (pim_nbr == NULL)
+        return;
+
+    if (flags & MRTF_SG)
+        add_jp_entry(pim_nbr, holdtime, mrt->group->group,
+                     SINGLE_GRP_MSKLEN, mrt->source->address,
+                     SINGLE_SRC_MSKLEN, 0, PIM_ACTION_JOIN);
+    else
+        add_jp_entry(pim_nbr, holdtime, mrt->group->group,
+                     SINGLE_GRP_MSKLEN, mrt->group->rpaddr,
+                     SINGLE_SRC_MSKLEN, flags, PIM_ACTION_JOIN);
+    pack_and_send_jp_message(pim_nbr);
+}
 
 /*
  * TODO: NOT USED, probably buggy, but may need it in the future.

--- a/pim_proto.c
+++ b/pim_proto.c
@@ -705,7 +705,6 @@ int receive_pim_register(uint32_t reg_src, uint32_t reg_dst, char *msg, size_t l
         if (!mrtentry)
            return TRUE;
 
-        mrtentry->incoming = reg_vif_num;
         SET_TIMER(mrtentry->timer, PIM_DATA_TIMEOUT);
         mrtentry->flags &= ~MRTF_NEW;
         change_interfaces(mrtentry,
@@ -2024,8 +2023,9 @@ int receive_pim_join_prune(uint32_t src, uint32_t dst __attribute__((unused)), c
 		 * be updated by change_interfaces()
 		 */
 		for (mrt_srcs = mrt->group->mrtlink; mrt_srcs; mrt_srcs = mrt_srcs->grpnext) {
-		    if (new_join && mrt_srcs->upstream) {
-			send_pim_join(mrt_srcs->upstream, mrt_srcs, MRTF_SG, PIM_JOIN_PRUNE_HOLDTIME);
+		    if (new_join) {
+			if (mrt_srcs->upstream)
+			    send_pim_join(mrt_srcs->upstream, mrt_srcs, MRTF_SG, PIM_JOIN_PRUNE_HOLDTIME);
 			VIFM_SET(vifi, mrt_srcs->joined_oifs);
 			VIFM_CLR(vifi, mrt_srcs->pruned_oifs);
 			VIFM_CLR(vifi, mrt_srcs->asserted_oifs);

--- a/route.c
+++ b/route.c
@@ -863,10 +863,11 @@ static void process_cache_miss(struct igmpmsg *igmpctl)
 			  mrt->asserted_oifs, 0);
     } else {
 	mrt = find_route(source, group, MRTF_SG | MRTF_WC | MRTF_PMBR, DONT_CREATE);
-	switch_shortest_path(source, group);
 	if (!mrt)
 	    return;
-    }
+        if (IN_PIM_SSM_RANGE(group))
+            switch_shortest_path(source, group);
+     }
 
     /* TODO: if there are too many cache miss for the same (S,G),
      * install negative cache entry in the kernel (oif==NULL) to prevent

--- a/route.c
+++ b/route.c
@@ -248,6 +248,7 @@ void add_leaf(vifi_t vifi, uint32_t source, uint32_t group)
     vifbitmap_t old_oifs;
     vifbitmap_t new_oifs;
     vifbitmap_t new_leaves;
+    uint16_t flags;
 
     /* Don't create routing entries for the LAN scoped addresses */
     if (ntohl(group) <= INADDR_MAX_LOCAL_GROUP) { /* group <= 224.0.0.255? */
@@ -274,8 +275,12 @@ void add_leaf(vifi_t vifi, uint32_t source, uint32_t group)
      * The downside is that a last-hop router may delay the initiation
      * of the SPT switch. Sigh...
      */
-    if (IN_PIM_SSM_RANGE(group))
+     /* Initialize flags */
+    flags = MRTF_RP | MRTF_WC;
+    if (IN_PIM_SSM_RANGE(group)) {
 	mrt = find_route(source, group, MRTF_SG, CREATE);
+	flags = MRTF_SG;
+    }
     else if (uvifs[vifi].uv_flags & VIFF_DR)
 	mrt = find_route(INADDR_ANY_N, group, MRTF_WC, CREATE);
     else
@@ -309,13 +314,14 @@ void add_leaf(vifi_t vifi, uint32_t source, uint32_t group)
 	/* A new created entry or the oifs have changed
 	 * from NULL to non-NULL. */
 	mrt->flags &= ~MRTF_NEW;
-	FIRE_TIMER(mrt->jp_timer); /* Timeout the Join/Prune timer */
-
-	/* TODO: explicitly call the function below?
-	send_pim_join_prune(mrt->upstream->vifi,
-			    mrt->upstream,
-			    PIM_JOIN_PRUNE_HOLDTIME);
-	*/
+	if (mrt->upstream) {
+	    send_pim_join(mrt->upstream, mrt, flags, PIM_JOIN_PRUNE_HOLDTIME);
+	    SET_TIMER(mrt->jp_timer, PIM_JOIN_PRUNE_PERIOD);
+	}
+	else  {
+	    FIRE_TIMER(mrt->jp_timer); /* Timeout the Join/Prune timer */
+	    logit(LOG_DEBUG, 0, "Upstream router not available.");
+	}
     }
 
     /* Check all (S,G) entries and set the inherited "leaf" flag.
@@ -332,6 +338,12 @@ void add_leaf(vifi_t vifi, uint32_t source, uint32_t group)
 			  srcs->pruned_oifs,
 			  new_leaves,
 			  srcs->asserted_oifs, 0);
+	/* In the case of SG entry we can create MFC directy without waiting for cache miss. */
+	if (flags & MRTF_SG) {
+	    add_kernel_cache(srcs, srcs->source->address, srcs->group->group, MFC_MOVE_FORCE);
+	    k_chg_mfc(igmp_socket, srcs->source->address, srcs->group->group, 
+		      srcs->incoming, srcs->oifs, srcs->source->address);
+	}
     }
 }
 


### PR DESCRIPTION
Here are couple of separate optimizations to multicast stream creation. Each commit optimizes one functionality (exept first one that is pure bug fix to my opinion). 

Pull request is made due to issue #58. There still might be sequences that are not optimized yet, but at least most obvious ones are now covered. 

Commit "Create MRT entry once PIM Register is received even ..." might be such that it does not follow RFC completely. But if it is not done, there will be 0 - 60 second delay in such scenario. 

I would be happy to discuss about the proposed changes and it would be great if there are people who would like to test the patch and give their opinion if it solves delay problems. 