### PR TITLE
logit(): rate-limit only what is being logged

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -55,6 +55,8 @@ unsigned long debug = 0x00000000;        /* If (long) is smaller than
 static char dumpfilename[] = _PATH_PIMD_DUMP;
 static char cachefilename[] = _PATH_PIMD_CACHE; /* TODO: notused */
 
+extern int syslog_level;
+
 
 char *packet_kind(int proto, int type, int code)
 {
@@ -427,12 +429,13 @@ void logit(int severity, int syserr, const char *format, ...)
      * Always log things that are worse than warnings, no matter what
      * the log_nmsgs rate limiter says.
      *
-     * Only count things worse than debugging in the rate limiter (since
-     * if you put daemon.debug in syslog.conf you probably actually want
-     * to log the debugging messages so they shouldn't be rate-limited)
+     * Only count things at the defined loglevel or worse in the rate limiter
+     * and exclude debugging (since if you put daemon.debug in syslog.conf
+     * you probably actually want to log the debugging messages so they
+     * shouldn't be rate-limited)
      */
     if ((severity < LOG_WARNING) || (log_nmsgs < LOG_MAX_MSGS)) {
-	if (severity < LOG_DEBUG)
+	if ((severity <= syslog_level) && (severity != LOG_DEBUG))
 	    log_nmsgs++;
 
 	if (syserr) {


### PR DESCRIPTION
Hi,

There's a small bug in the syslog rate-limiting logic: it takes into account all messages with severity other than LOG_DEBUG, regardless of whether they would actually be logged or not (according to the --loglevel setting). By default, this means that the unprinted LOG_INFO messages might cause pimd to enter a period of slience, although it actually hasn't printed anything. This is an example from a real system:
```
# grep pimd /var/log/syslog
Feb 12 12:58:54 sparrow pimd[1121]: pimd version 2.3.0 starting ...
Feb 12 12:59:54 sparrow pimd[1122]: logging too fast, shutting up for 10 minutes
Feb 12 13:09:54 sparrow pimd[1122]: logging enabled again after rate limiting
Feb 12 13:10:54 sparrow pimd[1122]: logging too fast, shutting up for 10 minutes
Feb 12 13:20:54 sparrow pimd[1122]: logging enabled again after rate limiting
Feb 12 13:21:54 sparrow pimd[1122]: logging too fast, shutting up for 10 minutes
Feb 12 13:31:54 sparrow pimd[1122]: logging enabled again after rate limiting
Feb 12 13:32:54 sparrow pimd[1122]: logging too fast, shutting up for 10 minutes
Feb 12 13:42:54 sparrow pimd[1122]: logging enabled again after rate limiting
Feb 12 13:43:54 sparrow pimd[1122]: logging too fast, shutting up for 10 minutes
Feb 12 13:53:54 sparrow pimd[1122]: logging enabled again after rate limiting
Feb 12 13:54:54 sparrow pimd[1122]: logging too fast, shutting up for 10 minutes
```

As you can see, pimd rate-limits its syslog output although nothing has been logged. What has not been logged are approx. 200 LOG_INFO messages regarding group joins.

Fix this by taking syslog_level into account before bumping log_nmsgs.