### PR TITLE
README: don't say it's possible to use loopback, it's not

### DIFF
--- a/pimd.conf
+++ b/pimd.conf
@@ -114,7 +114,6 @@
 # source preference and metric settings, but before everything else.
 
 # By default, all non-loopback multicast capable interfaces are enabled.
-# If you want to use loopback, set the interface multicast flag on it.
 #phyint eth0 disable
 
 # IGMP default query interval and querier timeout.  The latter should


### PR DESCRIPTION
In b81bbd, it was added that using loopback should be possible if
multicast flag was added. However, in `config.c`, `IFF_LOOPBACK` flag on
an interface makes it impossible to use a loopback interface.

In fact, I would be very interested to use the loopback. I would like to send local traffic to a multicast address but I have multiple output interfaces. I'd like to be able to bind to loopback and let pimd advertises the multicast endpoint. So I'll try to remove the limitation in `config.c` instead.