### PR TITLE
Update .gitignore to ignore autoconf files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,14 @@ ChangeLog.*
 
 build-stamp
 configure-stamp
+
+# autoconf
+/Makefile.in
+/aclocal.m4
+/autom4te.cache/
+/compile
+/config.h.in
+/configure
+/depcomp
+/install-sh
+/missing


### PR DESCRIPTION
When using `./autogen.sh`, we get some files that should be ignored from
Git. `./configure` will generate more files, but it's easy to avoid them
by using an out-of-tree build (that's what I am doing).

Signed-off-by: Vincent Bernat <vincent@bernat.im>