### PR TITLE
config: allow to use a loopback interface

### DIFF
--- a/config.c
+++ b/config.c
@@ -172,8 +172,8 @@ void config_vifs_from_kernel(void)
 	    logit(LOG_ERR, errno, "Failed reading interface flags for phyint %s", ifr.ifr_name);
 
 	flags = ifr.ifr_flags;
-	if ((flags & (IFF_LOOPBACK | IFF_MULTICAST)) != IFF_MULTICAST) {
-	    WARN("Skipping interface %s, either loopback or does not support multicast.", ifr.ifr_name);
+	if (!(flags & IFF_MULTICAST)) {
+	    WARN("Skipping interface %s, does not support multicast.", ifr.ifr_name);
 	    continue;
 	}
 


### PR DESCRIPTION
As per documentation, a loopback interface should be allowed once the
multicast flag has been enabled (with `ip link set multicast on dev
lo`). Enabling pimd on a loopback interface seems to work just fine on
Linux.

Signed-off-by: Vincent Bernat <vincent@bernat.im>