### PR TITLE
Allow use of loopback addresses (/32)

### DIFF
--- a/config.c
+++ b/config.c
@@ -199,9 +199,7 @@ void config_vifs_from_kernel(void)
 	}
 
 	subnet = addr & mask;
-#ifdef DISABLE_MASKLEN_CHECK
 	if (mask != 0xffffffff) {
-#endif
 		if ((!inet_valid_subnet(subnet, mask)) || (addr == subnet) || addr == (subnet | ~mask)) {
 			if (!(inet_valid_host(addr) && ((mask == htonl(0xfffffffe)) || (flags & IFF_POINTOPOINT)))) {
 				logit(LOG_WARNING, 0, "Ignoring %s, has invalid address %s and/or netmask %s",
@@ -209,9 +207,7 @@ void config_vifs_from_kernel(void)
 				continue;
 			}
 		}
-#ifdef DISABLE_MASKLEN_CHECK
 	}
-#endif
 
 	/*
 	 * Ignore any interface that is connected to the same subnet as

--- a/configure.ac
+++ b/configure.ac
@@ -81,9 +81,6 @@ AC_ARG_ENABLE(pim_genid,
 AC_ARG_ENABLE(exit_on_error,
         AS_HELP_STRING([--disable-exit-on-error], [Do not exit on error messages (LOG_ERR)]))
 
-AC_ARG_ENABLE(masklen_check,
-        AS_HELP_STRING([--disable-masklen-check], [Allow virtual tunctl VIFs with prefix len 32]))
-
 
 AC_ARG_WITH(max_vifs,
 	AS_HELP_STRING([--with-max-vifs=NUM], [Kernel maximum number of allowed VIFs, default: 32.
@@ -115,9 +112,6 @@ AS_IF([test "x$enable_pim_genid" != "xno"], [
 
 AS_IF([test "x$enable_exit_on_error" = "xno"], [
 	AC_DEFINE(CONTINUE_ON_ERROR, 1, [Do not exit on error messages (LOG_ERR).])])
-
-AS_IF([test "x$enable_masklen_check" = "xno"], [
-	AC_DEFINE(DISABLE_MASKLEN_CHECK, 1, [Allow virtual tunctl VIFs with prefix len 32.])])
 
 AS_IF([test "x$with_max_vifs" != "xno" -a "x$max_vifs" != "xyes"], [
 	AC_DEFINE_UNQUOTED(CUSTOM_MAX_VIFS, $max_vifs, [Custom MAX VIFs in kernel.])])


### PR DESCRIPTION
pimd had to be compiled with --disable-masklen-check to allow the use of
loopback addresses (/32). The option is a bit a misnomer as it really
only enables the use of a /32, not any masklen.

As it is considered a good practice when having multiple interfaces to
put C-BSR/C-RP on a loopback interface, it seems better to enable the
ability to do so by default in pimd.

This commit just removes the compile-time option and enables it by
default.

If this is too intrusive, I can also add a runtime flag for this option (whose default value depends on the compile-time flag).