### PR TITLE
Make SSM virtual RP address endian-independent

### DIFF
--- a/src/mrt.c
+++ b/src/mrt.c
@@ -218,7 +218,7 @@ mrtentry_t *find_route(uint32_t source, uint32_t group, uint16_t flags, char cre
 		   has been disabled for SSM also in PIM protocol.
 		   The address does not need to be really configured in any interface.
 		   TODO: Avoid need for virtual RP by implementing SSM-specific state structures */
-		add_rp_grp_entry(&cand_rp_list, &grp_mask_list, 0x0100fea9, 20, 90, group,
+		add_rp_grp_entry(&cand_rp_list, &grp_mask_list, htonl(0xa9fe0001), 20, 90, group,
 				 0xffffffff, curr_bsr_hash_mask, curr_bsr_fragment_tag);
 	    }
 	}


### PR DESCRIPTION
Replace the hard-coded byte-inverted hex code for 169.254.0.1,
which is 0x0100fea9, with htonl(0xa9fe0001) to support big-endian
architectures.

This is needed since add_rp_grp_entry() ultimately passes the
address to inet_valid_host() and ntohl().

Signed-off-by: Jean-Pierre Tosoni <jp.tosoni@acksys.fr>