### PR TITLE
Fix a double-free when daemon is restarting.

### DIFF
--- a/src/vif.c
+++ b/src/vif.c
@@ -399,7 +399,7 @@ static void stop_vif(vifi_t vifi)
 
 	    while (a->al_sources) {
 		b = a->al_sources;
-		a->al_sources = a->al_next;
+		a->al_sources = b->al_next;
 		free(b);
 	    }
 


### PR DESCRIPTION
When pimd receives SIGHUP signal and in the Source-specific multicast case, it
will restart and the sources list in the VIF table will be freed. However the
source node gets double freed due to an error in walking the list. The correct
pointer to the next node needs to be set.

Signed-off-by: Xiaodong Xu <stid.smth@gmail.com>