### PR TITLE
Fix RP hold time computation

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -660,10 +660,7 @@ static void dump_rpgrp(FILE *fp, rp_grp_entry_t *rpgrp, int indent)
 {
     grp_mask_t *grp = rpgrp->group;
 
-    if (indent)
-	fprintf(fp, "                           ");
-
-    fprintf(fp, "%-18.18s  %-8u  %-8u\n",
+    fprintf(fp, "                           %-18.18s  %-8u  %-8u\n",
 	    netname(grp->group_addr, grp->group_mask),
 	    rpgrp->priority, rpgrp->holdtime);
 }
@@ -680,17 +677,13 @@ int dump_rp_set(FILE *fp)
     fprintf(fp, "RP address       Incoming  Group Prefix        Priority  Holdtime\n");
     fprintf(fp, "---------------  --------  ------------------  --------  ---------------------\n");
     for (rp = cand_rp_list; rp; rp = rp->next) {
-	fprintf(fp, "%-15s  %-8d  ",
+	fprintf(fp, "%-15s  %-8d                                %-8u\n",
 		inet_fmt(rp->rpentry->address, s1, sizeof(s1)),
-		rp->rpentry->incoming);
+		rp->rpentry->incoming,
+		rp->rpentry->adv_holdtime);
 
-	rpgrp = rp->rp_grp_next;
-	if (rpgrp) {
-	    dump_rpgrp(fp, rpgrp, 0);
-
-	    for (rpgrp = rpgrp->rp_grp_next; rpgrp; rpgrp = rpgrp->rp_grp_next)
+	for (rpgrp = rp->rp_grp_next; rpgrp; rpgrp = rpgrp->rp_grp_next)
 		dump_rpgrp(fp, rpgrp, 1);
-	}
     }
 
     fprintf(fp, "------------------------------------------------------------------------------\n");

--- a/src/mrt.h
+++ b/src/mrt.h
@@ -132,6 +132,7 @@ typedef struct srcentry {
     uint32_t		  preference;	/* The metric preference (for assers)*/
     uint16_t		  timer;	/* Entry timer??? Delete?	    */
     struct cand_rp	 *cand_rp;	/* Used if this is rpentry_t	    */
+    uint16_t		 adv_holdtime;	/* rpentry_t: RP advertized holdtime*/
 } srcentry_t;
 typedef srcentry_t rpentry_t;
 

--- a/src/pim_proto.c
+++ b/src/pim_proto.c
@@ -3507,6 +3507,9 @@ int receive_pim_cand_rp_adv(uint32_t src, uint32_t dst __attribute__((unused)), 
     GET_BYTE(priority, data_ptr);
     GET_HOSTSHORT(holdtime, data_ptr);
     GET_EUADDR(&euaddr, data_ptr);
+    /* Is holdtime in MUST BE interval? (RFC5059 section 3.3) */
+    if (holdtime != 0 && holdtime <= PIM_BOOTSTRAP_PERIOD)
+	holdtime = PIM_BOOTSTRAP_TIMEOUT; /* no, set to the SHOULD BE value */
     if (prefix_cnt == 0) {
 	/* The default 224.0.0.0 and masklen of 4 */
 	MASKLEN_TO_MASK(ALL_MCAST_GROUPS_LEN, grp_mask);


### PR DESCRIPTION
This one has side effects, see commit message.

Not sure if I should take some extra caution steps for compatibility.

By the way, there is this fishy code in pimd.h:
```
/* TODO: 60 is the original value. Temporarily set to 30 for debugging.
#define PIM_BOOTSTRAP_PERIOD             60 */
#define PIM_BOOTSTRAP_PERIOD             30
```
The correct value is 60 per RFC, but changing it could render pimd less reactive maybe?