### PR TITLE
Allow configuration of BSR messages interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,13 @@ feature called *Bootstrap Router*.  The elected BSR in a PIM-SM domain
 periodically announces the RP set in Bootstrap messages.  For details on
 PIM BSR operation, see [RFC 5059](http://tools.ietf.org/search/rfc5059).
 
-    bsr-candidate [address | ifname] [priority <0-255>]
+    bsr-candidate [address | ifname] [priority <0-255>] [interval <10-26214>]
 
 The configuration of a Candidate BootStrap Router (CBSR) is very similar
-to that of CRP, except for the interval.  If either the address or the
-interface name is left out `pimd` uses the highest active IP address.
-If the priority is left out, `pimd` (like Cisco) defaults to priority 0.
+to that of CRP.  If either the address or the interface name is left out
+`pimd` uses the highest active IP address.  If the priority is left out,
+`pimd` (like Cisco) defaults to priority 0.  If the interval is left out,
+it defaults to the RFC value of 60 seconds.
 
 To *disable CRP and CBSR* completely in `pimd`, simply comment the two
 lines out from your `pimd.conf`, and make sure `pimd` can find the file.

--- a/pimd.conf
+++ b/pimd.conf
@@ -27,7 +27,7 @@
 #        [altnet <network> [/<masklen> | masklen <masklen>]]
 #        [scoped <network> [/<masklen> | masklen <masklen>]]
 #
-# bsr-candidate [local-addr | ifname] [priority <0-255>]
+# bsr-candidate [local-addr | ifname] [priority <0-255>] [interval <10-26214>]
 # rp-candidate  [local-addr | ifname] [priority <0-255> ] [interval <10-16383>]
 #                group-prefix <group-addr>[/<masklen> | masklen <masklen>]
 #                group-prefix <group-addr>[/<masklen> | masklen <masklen>]
@@ -93,6 +93,10 @@
 # unspecified, the largest local IP address will be used, excluding
 # phyint interfaces where PIM has been disabled.
 #
+# The bsr-candidate interval specifies Cand-BSR advertisement interval,
+# the default is 60 sec.  Use smaller values for faster convergence.
+# Note that the RP hold time is adjusted to exceed the BSR interval.
+#
 # The rp-candidate interval specifies Cand-RP advertisement interval,
 # the default is 30 sec.  Use smaller values for faster convergence.
 #
@@ -131,7 +135,7 @@
 #igmp-querier-timeout 42
 
 # Bigger value means  "higher" priority
-bsr-candidate priority 5
+bsr-candidate priority 5 interval 30
 
 # Smaller value means "higher" priority
 rp-candidate priority 20 interval 30

--- a/src/defs.h
+++ b/src/defs.h
@@ -344,6 +344,9 @@ extern uint32_t          curr_bsr_address;
 extern uint32_t          curr_bsr_hash_mask;
 extern uint8_t		 cand_bsr_flag;		   /* candidate BSR flag */
 extern uint8_t           my_bsr_priority;
+extern uint16_t          my_bsr_adv_period;        /* RFC5059: BS_Period */
+extern uint16_t          my_bsr_timeout;           /* RFC5059: BS_Timeout */
+extern uint16_t          recommended_rp_holdtime;  /* RFC5059: RP_Holdtime */
 extern uint32_t          my_bsr_address;
 extern uint32_t          my_bsr_hash_mask;
 extern uint8_t           cand_rp_flag;              /* Candidate RP flag */

--- a/src/pim_proto.c
+++ b/src/pim_proto.c
@@ -3310,7 +3310,7 @@ int receive_pim_bootstrap(uint32_t src, uint32_t dst, char *msg, size_t len)
     curr_bsr_priority     = new_bsr_priority;
     curr_bsr_fragment_tag = new_bsr_fragment_tag;
     MASKLEN_TO_MASK(new_bsr_hash_masklen, curr_bsr_hash_mask);
-    SET_TIMER(pim_bootstrap_timer, PIM_BOOTSTRAP_TIMEOUT);
+    SET_TIMER(pim_bootstrap_timer, my_bsr_timeout);
 
     while (data + min_datalen <= max_data) {
 	GET_EGADDR(&curr_group_addr, data);
@@ -3508,8 +3508,8 @@ int receive_pim_cand_rp_adv(uint32_t src, uint32_t dst __attribute__((unused)), 
     GET_HOSTSHORT(holdtime, data_ptr);
     GET_EUADDR(&euaddr, data_ptr);
     /* Is holdtime in MUST BE interval? (RFC5059 section 3.3) */
-    if (holdtime != 0 && holdtime <= PIM_BOOTSTRAP_PERIOD)
-	holdtime = PIM_BOOTSTRAP_TIMEOUT; /* no, set to the SHOULD BE value */
+    if (holdtime != 0 && holdtime <= my_bsr_adv_period)
+	holdtime = recommended_rp_holdtime;
     if (prefix_cnt == 0) {
 	/* The default 224.0.0.0 and masklen of 4 */
 	MASKLEN_TO_MASK(ALL_MCAST_GROUPS_LEN, grp_mask);

--- a/src/pimd.h
+++ b/src/pimd.h
@@ -70,8 +70,11 @@
 #define PIM_DEFAULT_CAND_RP_ADV_PERIOD   60
 #define PIM_MAX_CAND_RP_ADV_PERIOD       16383
 
-#define PIM_BOOTSTRAP_PERIOD             60
-#define PIM_BOOTSTRAP_TIMEOUT	       (2.5 * PIM_BOOTSTRAP_PERIOD + 10)
+#define PIM_BOOTSTRAP_PERIOD             60 /* RFC5059 section 5 */
+#define PIM_MIN_BOOTSTRAP_PERIOD         10 /* RFC5059 section 5 */
+/* Let RP holdtime fit in 16 bits in the BSM */
+#define PIM_MAX_BOOTSTRAP_PERIOD     (65535 / 2.5)
+
 #define PIM_TIMER_HELLO_HOLDTIME       (3.5 * PIM_TIMER_HELLO_INTERVAL)
 #define PIM_ASSERT_TIMEOUT              180
 

--- a/src/rp.c
+++ b/src/rp.c
@@ -50,6 +50,9 @@ uint32_t                 curr_bsr_hash_mask;
 uint16_t                 pim_bootstrap_timer;   /* For electing the BSR and
 						 * sending Cand-RP-set msgs */
 uint8_t                  my_bsr_priority;
+uint16_t                 my_bsr_adv_period;
+uint16_t                 my_bsr_timeout;
+uint16_t                 recommended_rp_holdtime;
 uint32_t                 my_bsr_address;
 uint32_t                 my_bsr_hash_mask;
 uint8_t                  cand_bsr_flag = FALSE; /* Set to TRUE if I am
@@ -96,7 +99,7 @@ void init_rp_and_bsr(void)
 	curr_bsr_priority = 0;             /* Lowest priority */
 	curr_bsr_address  = INADDR_ANY_N;  /* Lowest priority */
 	MASKLEN_TO_MASK(RP_DEFAULT_IPV4_HASHMASKLEN, curr_bsr_hash_mask);
-	SET_TIMER(pim_bootstrap_timer, PIM_BOOTSTRAP_TIMEOUT);
+	SET_TIMER(pim_bootstrap_timer, my_bsr_timeout);
     } else {
 	curr_bsr_fragment_tag = RANDOM();
 	curr_bsr_priority = my_bsr_priority;
@@ -880,8 +883,8 @@ int create_pim_bootstrap_message(char *send_buff)
 	for (entry_ptr = mask_ptr->grp_rp_next; entry_ptr; entry_ptr = entry_ptr->grp_rp_next) {
 	    holdtime = entry_ptr->rp->rpentry->adv_holdtime;
 	    /* Is holdtime in MUST BE interval? (RFC5059 section 3.3) */
-	    if (holdtime != 0 && holdtime <= PIM_BOOTSTRAP_PERIOD)
-	    	holdtime = PIM_BOOTSTRAP_TIMEOUT; /* no, set to the SHOULD BE value */
+	    if (holdtime != 0 && holdtime <= my_bsr_adv_period)
+		holdtime = recommended_rp_holdtime;
 	    PUT_EUADDR(entry_ptr->rp->rpentry->address, data_ptr);
 	    PUT_HOSTSHORT(holdtime, data_ptr);
 	    PUT_BYTE(entry_ptr->priority, data_ptr);

--- a/src/timer.c
+++ b/src/timer.c
@@ -823,7 +823,7 @@ void age_misc(void)
 	if (cand_bsr_flag == FALSE) {
 	    /* If I am not Cand-BSR, start accepting Bootstrap messages from anyone.
 	     * XXX: Even if the BSR has timeout, the existing Cand-RP-Set is kept. */
-	    SET_TIMER(pim_bootstrap_timer, PIM_BOOTSTRAP_TIMEOUT);
+	    SET_TIMER(pim_bootstrap_timer, my_bsr_timeout);
 	    curr_bsr_fragment_tag = 0;
 	    curr_bsr_priority     = 0;		  /* Lowest priority */
 	    curr_bsr_address      = INADDR_ANY_N; /* Lowest priority */
@@ -831,7 +831,7 @@ void age_misc(void)
 	} else {
 	    /* I am Cand-BSR, so set the current BSR to me */
 	    if (curr_bsr_address == my_bsr_address) {
-		SET_TIMER(pim_bootstrap_timer, PIM_BOOTSTRAP_PERIOD);
+		SET_TIMER(pim_bootstrap_timer, my_bsr_adv_period);
 		send_pim_bootstrap();
 	    } else {
 		/* Short delay before becoming the BSR and start sending


### PR DESCRIPTION
Add an 'interval' option to bsr-candidate command.  This parameter
is named [BS_Period] in RFC5059.  Adjust pimd.conf documentation
accordingly.

Precompute BSR timeout and recommended RP hold time from BSR interval.

Signed-off-by: Jean-Pierre Tosoni <jp.tosoni@acksys.fr>