### PR TITLE
Add Dockerfile to compile and package pimd/pimctl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:stretch
+
+COPY . /root/pimd
+WORKDIR /root/pimd
+RUN apt-get update && apt-get install -y build-essential automake
+RUN ./autogen.sh
+RUN ./configure --prefix=/usr --sysconfdir=/etc
+RUN make
+
+FROM debian:stretch
+COPY --from=0 /root/pimd/src/pimd /root/pimd/src/pimctl /usr/sbin/
+
+CMD [ "/usr/sbin/pimd", "--foreground" ]


### PR DESCRIPTION
Multistage Dockerfile based on debian:stretch

stage 0: build pimd, pimctl
stage 1: install to /usr/sbin/{pimd,pimctl}