### PR TITLE
vif.c: Fallback on routing table for neighbor checks

### DIFF
--- a/src/vif.c
+++ b/src/vif.c
@@ -590,6 +590,7 @@ vifi_t find_vif_direct(uint32_t src)
     vifi_t vifi;
     struct uvif *v;
     struct phaddr *p;
+    struct rpfctl rpf;
 
     for (vifi = 0, v = uvifs; vifi < numvifs; ++vifi, ++v) {
 	if (v->uv_flags & (VIFF_DISABLED | VIFF_DOWN | VIFF_REGISTER | VIFF_TUNNEL))
@@ -611,6 +612,13 @@ vifi_t find_vif_direct(uint32_t src)
 	/* POINTOPOINT but not VIFF_TUNNEL interface (e.g., GRE) */
 	if ((v->uv_flags & VIFF_POINT_TO_POINT) && (src == v->uv_rmt_addr))
 	    return vifi;
+    }
+
+    /* Check if the routing table has a direct route (no gateway). */
+    if (k_req_incoming(src, &rpf)) {
+	if (rpf.source.s_addr == rpf.rpfneighbor.s_addr) {
+	    return rpf.iif;
+	}
     }
 
     return NO_VIF;
@@ -650,6 +658,7 @@ vifi_t find_vif_direct_local(uint32_t src)
     vifi_t vifi;
     struct uvif *v;
     struct phaddr *p;
+    struct rpfctl rpf;
 
     for (vifi = 0, v = uvifs; vifi < numvifs; ++vifi, ++v) {
 	/* TODO: XXX: what about VIFF_TUNNEL? */
@@ -672,6 +681,13 @@ vifi_t find_vif_direct_local(uint32_t src)
 	/* POINTOPOINT but not VIFF_TUNNEL interface (e.g., GRE) */
 	if ((v->uv_flags & VIFF_POINT_TO_POINT) && (src == v->uv_rmt_addr))
 	    return vifi;
+    }
+
+    /* Check if the routing table has a direct route (no gateway). */
+    if (k_req_incoming(src, &rpf)) {
+	if (rpf.source.s_addr == rpf.rpfneighbor.s_addr) {
+	    return rpf.iif;
+	}
     }
 
     return NO_VIF;


### PR DESCRIPTION
The proposed change falls back on the routing table allows to check for such a direct route as a last resort for determining adjacency to a PIM router. There may be something that I have overlooked in making this change. I am currently using this in a test network, which uses FRR's isisd to advertise /32 routes for neighboring routers, which are also PIM routers. With such a setup, FRR will fill in the kernel's routing table with entries like "10.0.0.3 via 10.0.0.3 dev ens37 onlink" which allows IP communications to be possible despite the lack of a shared subnet.

Outside of my test network, I have been using this type of deployment with Cisco routers for several years, and recent improvements to FRR's isisd combined with this improvement to your pimd potentially opens up the possibility of eliminating my dependency on Cisco.
