### PR TITLE
fix erroneous infos about DR in show neighbors/interfaces

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -325,8 +325,9 @@ static int show_neighbor(FILE *fp, struct uvif *uv, pim_nbr_entry_t *n)
 		 timetostr(uptime, tmp, sizeof(tmp)),
 		 timetostr(n->timer, NULL, 0));
 
+	tmp[0] = '\0';
 	if ((uv->uv_flags & VIFF_DR) == 0) {
-		if (uv->uv_pim_neighbors == n)
+		if (uv->uv_pim_neighbor_dr == n)
 			snprintf(tmp, sizeof(tmp), "DR");
 	}
 
@@ -374,9 +375,9 @@ static void show_interface(FILE *fp, struct uvif *uv)
 		addr = uv->uv_lcl_addr;
 		snprintf(tmp, sizeof(tmp), "%d", uv->uv_dr_prio);
 		pri  = tmp;
-	} else if (uv->uv_pim_neighbors) {
-		addr = uv->uv_pim_neighbors->address;
-		pri  = get_dr_prio(uv->uv_pim_neighbors);
+	} else if (uv->uv_pim_neighbor_dr) {
+		addr = uv->uv_pim_neighbor_dr->address;
+		pri  = get_dr_prio(uv->uv_pim_neighbor_dr);
 	}
 
 	for (n = uv->uv_pim_neighbors; n; n = n->next)

--- a/src/vif.c
+++ b/src/vif.c
@@ -182,6 +182,7 @@ void zero_vif(struct uvif *v, int t)
     RESET_TIMER(v->uv_gq_timer);
     RESET_TIMER(v->uv_jp_timer);
     v->uv_pim_neighbors	= (struct pim_nbr_entry *)NULL;
+    v->uv_pim_neighbor_dr = (struct pim_nbr_entry *)NULL;
     v->uv_local_pref	= default_route_distance;
     v->uv_local_metric	= default_route_metric;
     v->uv_ifindex	= -1;
@@ -311,6 +312,7 @@ static void start_vif(vifi_t vifi)
 	/* TODO: CHECK THE TIMERS!!!!! Set or reset? */
 	RESET_TIMER(v->uv_gq_timer);
 	v->uv_pim_neighbors = (pim_nbr_entry_t *)NULL;
+	v->uv_pim_neighbor_dr = (pim_nbr_entry_t *)NULL;
     }
 
     /* Tell kernel to add, i.e. start this vif */
@@ -428,6 +430,7 @@ static void stop_vif(vifi_t vifi)
 	    delete_pim_nbr(n);
 	}
 	v->uv_pim_neighbors = NULL;
+	v->uv_pim_neighbor_dr = NULL;
     }
 
     /* TODO: currently not used */

--- a/src/vif.h
+++ b/src/vif.h
@@ -213,6 +213,7 @@ struct uvif {
     int             uv_local_pref;  /* default local preference for assert  */
     int             uv_local_metric;/* default local metric for assert      */
     struct pim_nbr_entry *uv_pim_neighbors; /* list of PIM neighbor routers */
+    struct pim_nbr_entry *uv_pim_neighbor_dr; /* Neighbor with DR role, if any (referenced from uv_pim_neighbors) */
     int             uv_ifindex;     /* because RTNETLINK returns only index */
 };
 


### PR DESCRIPTION
# Description of problem

Pimctl can show wrong information about the DR identity for a given subnet. (in both `sh neighbors` and `sh interfaces`).
If it is not itself, Pimd does not care about who is the DR but yet the information can be misleading. So even though the patch is mostly in pimd, it really just fixes info displayed by pimctl. 

# Solution

Fixing algorithm for electing the DR. 
Fixing display bug in the neihgbor table.

# Tests

Mounted a multicast network with 3 routers in parallel, with especially:
| Router | IP | Prio |
|-|-|-|
|1|192.168.20.171|5030|
|2|192.168.20.177|5020|
|3|192.168.20.181|5010|

```
Before :
_______________________________________________________________________________
PIM Interface Table
===============================================================================
Interface         State     Address          Nbr  Hello  Prio  DR Address 
===============================================================================
vtnet1            Up        192.168.20.171     2      5  5030  192.168.20.171 
vtnet2            Up        192.168.21.182     2      5     1  192.168.21.186

===============================================================================
vtnet1            Up        192.168.20.177     2      5  5010  192.168.20.181 
vtnet2            Up        192.168.21.186     2      5     1  192.168.21.186

===============================================================================
vtnet1            Up        192.168.20.181     2      5  5020  192.168.20.177 
vtnet2            Up        192.168.21.140     2      5     1  192.168.21.186
```
```
After:
_______________________________________________________________________________
PIM Interface Table
===============================================================================
Interface         State     Address          Nbr  Hello  Prio  DR Address 
===============================================================================
vtnet1            Up        192.168.20.171     2      5  5030  192.168.20.171 
vtnet2            Up        192.168.21.182     2      5     1  192.168.21.186

===============================================================================
vtnet1            Up        192.168.20.177     2      5  5030  192.168.20.171 
vtnet2            Up        192.168.21.186     2      5     1  192.168.21.186

===============================================================================
vtnet1            Up        192.168.20.181     2      5  5030  192.168.20.171 
vtnet2            Up        192.168.21.140     2      5     1  192.168.21.186
```

- Fixing output of `pimctl sh neighbors` :
```
Before:
_______________________________________________________________________________
PIM Neighbor Table
===============================================================================
Interface         Address          Prio  Mode  Uptime/Expires               
===============================================================================
vtnet1            192.168.20.181   5010  0h1m7s  0h1m7s/0h0m12s              
vtnet1            192.168.20.177   5020  0h1m7s  0h1m7s/0h0m17s              
vtnet2            192.168.21.186      1  DR    0h1m7s/0h0m17s              
vtnet2            192.168.21.140      1  0h1m7s  0h1m7s/0h0m17s
```
```
After:
_______________________________________________________________________________
PIM Neighbor Table
===============================================================================
Interface         Address          Prio  Mode  Uptime/Expires               
===============================================================================
vtnet1            192.168.20.181   5010        0h0m1s/0h0m17s              
vtnet1            192.168.20.177   5020        0h0m1s/0h0m17s              
vtnet2            192.168.21.186      1  DR    0h0m1s/0h0m17s              
vtnet2            192.168.21.140      1        0h0m1s/0h0m17s
```