### PR TITLE
fix: on some loops, pointer of uvifs start at 0 instead 1

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -373,7 +373,7 @@ init_vif_list:
 	 * one already installed in the uvifs array.  Skip reserved vifi
 	 * for PIMREG_VIF.
 	 */
-	for (vifi = 1, v = uvifs; vifi < numvifs; ++vifi, ++v) {
+	for (vifi = 1, v = &uvifs[1]; vifi < numvifs; ++vifi, ++v) {
 	    if (strcmp(v->uv_name, ifa->ifa_name) == 0) {
 		logit(LOG_DEBUG, 0, "Ignoring %s (%s on subnet %s) (alias for vif#%u?)",
 		      v->uv_name, inet_fmt(addr, s1, sizeof(s1)), netname(subnet, mask), vifi);
@@ -586,10 +586,6 @@ static int parse_phyint(char *s)
     }
 
     for (vifi = 0, v = uvifs; vifi < numvifs; ++vifi, ++v) {
-	if (vifi == numvifs) {
-	    WARN("phyint %s is not a valid interface", inet_fmt(local, s1, sizeof(s1)));
-	    return FALSE;
-	}
 
 	if (local != v->uv_lcl_addr)
 	    continue;
@@ -796,6 +792,10 @@ static int parse_phyint(char *s)
 	} /* while(... != "") */
 
 	break;
+    }
+    if (vifi == numvifs) {
+	WARN("phyint %s is not a valid interface", inet_fmt(local, s1, sizeof(s1)));
+	return FALSE;
     }
 
     return TRUE;

--- a/src/vif.c
+++ b/src/vif.c
@@ -105,12 +105,13 @@ void init_vifs(void)
 
     if (!do_vifs) {
 	/* Disable all VIFs by default (no phyint), except PIMREG_VIF */
-	for (vifi = 1, v = uvifs; vifi < numvifs; ++vifi, ++v)
+	for (vifi = 1, v = &uvifs[1]; vifi < numvifs; ++vifi, ++v)
           v->uv_flags |= VIFF_DISABLED;
     }
 
-    init_reg_vif();
     config_vifs_from_file();
+
+    init_reg_vif();
 
     /*
      * Quit if there are fewer than two enabled vifs.
@@ -119,7 +120,7 @@ void init_vifs(void)
     phys_vif        = -1;
 
     /* The PIM register tunnel interface should always be vifi 0 */
-    for (vifi = 1, v = uvifs; vifi < numvifs; ++vifi, ++v) {
+    for (vifi = 1, v = &uvifs[1]; vifi < numvifs; ++vifi, ++v) {
 	/*
 	 * Initialize the outgoing timeout for each vif.  Currently use
 	 * a fixed time.  Later, we may add a configurable array to feed


### PR DESCRIPTION
We have found somes mistakes.
In particular, it fixes the alias bug for vif.