### PR TITLE
on freebsd, in k_req_incoming, if source is local, the return value must be TRUE

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -49,12 +49,12 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <unistd.h> 
+#include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
 #include <syslog.h>
-#include <signal.h> 
-#include <string.h> 
+#include <signal.h>
+#include <string.h>
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <netinet/in_systm.h>
@@ -451,7 +451,7 @@ extern int		errno;
 #define NOT_TIMEOUT(timer)		\
 	((timer) -= (MIN(timer, TIMER_INTERVAL)))
 
-#define ELSE else           /* To make emacs cc-mode happy */      
+#define ELSE else           /* To make emacs cc-mode happy */
 
 #define MASK_TO_VAL(x, i) {		   \
 	uint32_t _x = ntohl(x);		   \
@@ -660,7 +660,7 @@ extern void	check_vif_state		(void);
 extern vifi_t	local_address		(uint32_t src);
 extern vifi_t	find_vif		(int ifi);
 extern vifi_t	find_vif_direct		(uint32_t src);
-extern vifi_t	find_vif_direct_local	(uint32_t src);
+extern vifi_t	find_vif_direct_local	(uint32_t src, uint8_t check_kernel_table);
 extern uint32_t	max_local_address	(void);
 extern void	age_vifs		(void);
 

--- a/src/pim_proto.c
+++ b/src/pim_proto.c
@@ -920,7 +920,7 @@ int send_pim_register(char *packet)
     if (IN_PIM_SSM_RANGE(group))
 	return FALSE; /* Group is in PIM-SSM range, don't send register. */
 
-    if ((vifi = find_vif_direct_local(source)) == NO_VIF)
+    if ((vifi = find_vif_direct_local(source, TRUE)) == NO_VIF)
 	return FALSE;
 
     if (!(uvifs[vifi].uv_flags & VIFF_DR))
@@ -1001,7 +1001,7 @@ int send_pim_null_register(mrtentry_t *mrtentry)
     uint32_t reg_src, reg_dst;
 
     /* No directly connected source; no local address */
-    if ((vifi = find_vif_direct_local(mrtentry->source->address))== NO_VIF)
+    if ((vifi = find_vif_direct_local(mrtentry->source->address, TRUE))== NO_VIF)
 	return FALSE;
 
     pim_register = (pim_register_t *)(pim_send_buf + sizeof(struct ip) +
@@ -2345,7 +2345,7 @@ int send_periodic_pim_join_prune(vifi_t vifi, pim_nbr_entry_t *pim_nbr, uint16_t
 	    if (mrt->flags & MRTF_RP) {
 		/* RPbit set */
 		addr = mrt->source->address;
-		if (PIMD_VIFM_ISEMPTY(mrt->joined_oifs) || find_vif_direct_local(addr) != NO_VIF) {
+		if (PIMD_VIFM_ISEMPTY(mrt->joined_oifs) || find_vif_direct_local(addr, TRUE) != NO_VIF) {
 		    /* TODO: XXX: TIMER implem. dependency! */
 		    if (grp->grp_route &&
 			grp->grp_route->incoming == vifi &&

--- a/src/route.c
+++ b/src/route.c
@@ -927,7 +927,7 @@ static void process_cache_miss(struct igmpmsg *igmpctl)
     /* If I am the DR for this source, create (S,G) and add the register_vif
      * to the oifs. */
 
-    if ((uvifs[iif].uv_flags & VIFF_DR) && (find_vif_direct_local(source) == iif)) {
+    if ((uvifs[iif].uv_flags & VIFF_DR) && (find_vif_direct_local(source, TRUE) == iif)) {
 	mrt = find_route(source, group, MRTF_SG, CREATE);
 	if (!mrt)
 	    return;

--- a/src/routesock.c
+++ b/src/routesock.c
@@ -161,27 +161,15 @@ int k_req_incoming(uint32_t source, struct rpfctl *rpf)
     /* initialize */
     rpf->source.s_addr      = source;
     rpf->rpfneighbor.s_addr = INADDR_ANY_N;
-#if 0
     /*
      * check if local address or directly connected before calling the
      * routing socket
      */
-    rpf->iif = find_vif_direct_local(source);
+    rpf->iif = find_vif_direct_local(source, FALSE);
     if (rpf->iif != NO_VIF) {
 	rpf->rpfneighbor.s_addr = source;
 	return TRUE;
     }
-#else
-    /*
-     * Cannot call find_vif_direct_local() anymore.  In c8d06b0a this fn
-     * was changed to call k_req_incoming(), i.e. us.  The change was
-     * made in the context of Linux (netlink), which already does not
-     * call find_vif_direct_local().
-     *
-     * XXX: Possibly we should've fixed netlink.c instead, but here we are.
-     */
-    rpf->iif = NO_VIF;
-#endif
 
     /* prepare the routing socket params */
     rtm_addrs |= RTA_DST;

--- a/src/vif.c
+++ b/src/vif.c
@@ -670,7 +670,7 @@ vifi_t local_address(uint32_t src)
  * (Register and tunnels excluded).
  * Return the vif number or NO_VIF if not found.
  */
-vifi_t find_vif_direct_local(uint32_t src)
+vifi_t find_vif_direct_local(uint32_t src, uint8_t check_kernel_table)
 {
     vifi_t vifi;
     struct uvif *v;
@@ -700,10 +700,12 @@ vifi_t find_vif_direct_local(uint32_t src)
 	    return vifi;
     }
 
-    /* Check if the routing table has a direct route (no gateway). */
-    if (k_req_incoming(src, &rpf)) {
-	if (rpf.source.s_addr == rpf.rpfneighbor.s_addr) {
-	    return rpf.iif;
+    if (check_kernel_table) {
+	/* Check if the routing table has a direct route (no gateway). */
+	if (k_req_incoming(src, &rpf)) {
+	    if (rpf.source.s_addr == rpf.rpfneighbor.s_addr) {
+		return rpf.iif;
+	    }
 	}
     }
 


### PR DESCRIPTION
Problem : the election of the BSR is unstable, if the BSR is on a direct route.

Solution : fix the regression brought by the commits :
The commit c8d06b0a3b277cdc8b488845973f4a33c58f112d modified `find_vif_direct_local()` to take into account addresses that are not part of the interfaces/masks but that are known by the kernel as direct. see https://github.com/troglobit/pimd/pull/153
The commit 4a6b1a94735b7c25de42d72d08ba7f33f7516662 fixed a blocking of pimd by a recusive call of k_req_incoming by removing the call to `find_vif_direct_local()`, which caused the regression.

The solution chosen is to add a parameter to `find_vif_direct_local()` to indicate whether a call to k_req_incoming is made.