### PR TITLE
fix: on rp election, some variables are not reset

### DIFF
--- a/src/rp.c
+++ b/src/rp.c
@@ -835,9 +835,13 @@ rp_grp_entry_t *rp_grp_match(uint32_t group)
 	if (curr_group_mask > mask_ptr->group_mask)
 	    continue;
 
-	/* reset best priority while mask get longer */
+	/* reset best priority/address/hash value while mask get longer */
 	if (curr_group_mask < mask_ptr->group_mask)
+	{
 	    best_priority = ~0;
+	    best_address_h = 0;
+	    best_hash_value = 0;
+	}
 
 	curr_hash_mask_h = ntohl(mask_ptr->hash_mask);
 	for (entry_ptr = mask_ptr->grp_rp_next; entry_ptr; entry_ptr = entry_ptr->grp_rp_next) {


### PR DESCRIPTION
In some cases, the RP selection mechanism does not work as intended.

For example:
with this list of RP:
```
===============================================================================
Group Address     RP Address       Prio  Holdtime  Type
===============================================================================
232/8             169.254.0.1         1   Forever  Static 
224.1.1           172.16.20.2         0        21  Dynamic
                  172.16.30.3        30       146  Dynamic
                  172.16.10.1        30       146  Dynamic
225.1.1.3/32      172.16.30.3        30       146  Dynamic
                  172.16.10.1        30       146  Dynamic
```
in the MRT, the RP elected is 172.16.30.3 instead of 172.16.20.2
```
_______________________________________________________________________________
Multicast Routing Table
===============================================================================
Source            Group            RP Address       Flags 
===============================================================================
192.168.121.11    224.1.1.1        172.16.30.3      CACHE SG
ANY               224.1.1.2        172.16.30.3      WC RP
192.168.121.11    225.1.1.3        172.16.30.3      CACHE SG
```
